### PR TITLE
add flexible kmer composition script and kmer abundance script

### DIFF
--- a/kmer-abundance.py
+++ b/kmer-abundance.py
@@ -37,7 +37,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    p = argparse.ArgumentParser(description='Count canonical 3-mers in a fasta file and write to a CSV file.')
+    p = argparse.ArgumentParser(description='Get whole-file abundances for k-mers each record.')
     p.add_argument('input_fasta', type=str, help='Path to the input fasta file')
     p.add_argument('input_sketch', type=str, help='Path to corresponding sketch size')
     p.add_argument('-k', '--ksize', type=int, default=3, help='K-mer size (default: 3)')

--- a/kmer-abundance.py
+++ b/kmer-abundance.py
@@ -15,6 +15,7 @@ def main(args):
     sig = siglist[0]
     fullfile_mh = sig.minhash.downsample(scaled=args.scaled)
 
+
     # generate fieldnames using hashvals
     fieldnames = ['name'] + list(fullfile_mh.hashes)
 
@@ -27,8 +28,9 @@ def main(args):
         for record in screed.open(args.input_fasta):
             # first get existing hashvals
             mh.add_sequence(record.sequence)
-            # then inflate with fullsig counts
-            kmers_to_ff_count = {hashval: fullfile_mh.hashes[hashval] for hashval in mh.hashes}
+            n_observed = len(mh) # total number kmers in this record
+            # then inflate with fullsig counts but normalize by n kmers in the record
+            kmers_to_ff_count = {hashval: (fullfile_mh.hashes[hashval]/n_observed) for hashval in mh.hashes}
             kmers_to_ff_count['name'] = record.name
             writer.writerow(kmers_to_ff_count)
             mh.copy_and_clear()

--- a/kmer-abundance.py
+++ b/kmer-abundance.py
@@ -1,0 +1,46 @@
+import csv
+import argparse
+import screed
+import sourmash
+
+def main(args):
+    """
+    Report abundance of kmers in reads/contigs FROM whole file and output to csv
+    """
+
+    # first, load whole-file sketch and downsample if needed
+    siglist = sourmash.load_file_as_signatures(args.input_sketch, ksize=args.ksize)
+    siglist = list(siglist)
+    assert len(siglist) == 1
+    sig = siglist[0]
+    fullfile_mh = sig.minhash.downsample(scaled=args.scaled)
+
+    # generate fieldnames using hashvals
+    fieldnames = ['name'] + list(fullfile_mh.hashes)
+
+    mh = sourmash.MinHash(n=0, ksize=args.ksize, scaled=args.scaled)
+    with open(args.output_csv, 'w', newline='') as csvfile:
+        # Just use hashvals as column headers, shrug. 
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for record in screed.open(args.input_fasta):
+            # first get existing hashvals
+            mh.add_sequence(record.sequence)
+            # then inflate with fullsig counts
+            kmers_to_ff_count = {hashval: fullfile_mh.hashes[hashval] for hashval in mh.hashes}
+            kmers_to_ff_count['name'] = record.name
+            writer.writerow(kmers_to_ff_count)
+            mh.copy_and_clear()
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description='Count canonical 3-mers in a fasta file and write to a CSV file.')
+    p.add_argument('input_fasta', type=str, help='Path to the input fasta file')
+    p.add_argument('input_sketch', type=str, help='Path to corresponding sketch size')
+    p.add_argument('-k', '--ksize', type=int, default=3, help='K-mer size (default: 3)')
+    p.add_argument('-s', '--scaled', type=int, default=50, help='Scaled value for MinHash (default: 50)')
+    p.add_argument('-o', '--output-csv', type=str, help='Path to the output CSV file')
+
+    args = p.parse_args()
+    main(args)

--- a/kmer-composition.py
+++ b/kmer-composition.py
@@ -1,0 +1,76 @@
+import csv
+import argparse
+import screed
+from itertools import product
+import sourmash
+from sourmash.minhash import hash_murmur
+import pytest
+
+
+def canonical_kmers_and_hashes(ksize):
+    """
+    Generate all unique canonical k-mers for a specified k-mer size and their hash values.
+    
+    Parameters:
+    - ksize: The size of the k-mer (int).
+    
+    Returns:
+    A dictionary where keys are canonical k-mer strings and values are their hash values for the given k-mer size.
+    """
+    bases = ['A', 'C', 'G', 'T']
+    all_kmers = [''.join(p) for p in product(bases, repeat=ksize)]
+    print(f'kmers at ksize {ksize}: ', len(all_kmers))
+    hashes_to_kmers = {}
+    seen_kmers=set()
+    for kmer in all_kmers:
+        # first, get canonical kmer
+        rev_comp = screed.rc(kmer) # get reverse complement
+        canonical_kmer = min(kmer, rev_comp)
+        
+        # Ensure we only compute and store the hash for each unique canonical k-mer once
+        if canonical_kmer not in seen_kmers:
+            hashval = hash_murmur(canonical_kmer)
+            hashes_to_kmers[hashval] = canonical_kmer
+            seen_kmers.add(canonical_kmer)
+    print(f'canonical kmers at ksize {ksize}: ', len(seen_kmers))
+    return hashes_to_kmers 
+
+
+def main(args):
+    """
+    Count abundance of kmers in reads/contigs and output to csv
+    """
+    hashes_to_kmers = canonical_kmers_and_hashes(args.ksize)
+    mh = sourmash.MinHash(n=0, ksize=args.ksize, scaled=args.scaled, track_abundance=True)
+    with open(args.output_csv, 'w', newline='') as csvfile:
+        # Use kmer idents rather than hashvals as fieldnames -- nicer csv headers :)
+        fieldnames = ['name'] + list(hashes_to_kmers.values())
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for record in screed.open(args.input_fasta):
+            # use sourmash to count abundances
+            mh.add_sequence(record.sequence)
+            # map hashvals to kmer idents to allow nicer csv headers :)
+            kmer_to_count = {hashes_to_kmers[hashval]: mh.hashes.get(hashval, 0) for hashval in hashes_to_kmers}
+            kmer_to_count['name'] = record.name
+            writer.writerow(kmer_to_count)
+            mh.copy_and_clear()
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description='Count canonical 3-mers in a fasta file and write to a CSV file.')
+    p.add_argument('input_fasta', type=str, help='Path to the input fasta file')
+    p.add_argument('-k', '--ksize', type=int, default=3, help='K-mer size (default: 3)')
+    p.add_argument('-s', '--scaled', type=int, default=50, help='Scaled value for MinHash (default: 50)')
+    p.add_argument('-o', '--output-csv', type=str, help='Path to the output CSV file')
+
+    args = p.parse_args()
+    main(args)
+
+
+# test canonical kmers fn
+def test_canonical_kmers_and_hashes():
+    kh = canonical_kmers_and_hashes(ksize=3)
+    assert len(kh) == 32
+    kh = canonical_kmers_and_hashes(ksize=4)
+    assert len(kh) == 136

--- a/kmer-composition.py
+++ b/kmer-composition.py
@@ -52,13 +52,14 @@ def main(args):
             # use sourmash to count abundances
             mh.add_sequence(record.sequence)
             # map hashvals to kmer idents to allow nicer csv headers :)
-            kmer_to_count = {hashes_to_kmers[hashval]: mh.hashes.get(hashval, 0) for hashval in hashes_to_kmers}
+            n_observed = len(mh) # total number kmers in this record
+            kmer_to_count = {hashes_to_kmers[hashval]: (mh.hashes.get(hashval, 0)/n_observed) for hashval in hashes_to_kmers}
             kmer_to_count['name'] = record.name
             writer.writerow(kmer_to_count)
             mh.copy_and_clear()
 
 if __name__ == "__main__":
-    p = argparse.ArgumentParser(description='Count canonical 3-mers in a fasta file and write to a CSV file.')
+    p = argparse.ArgumentParser(description='Get kmer composition of each sequence record in a file')
     p.add_argument('input_fasta', type=str, help='Path to the input fasta file')
     p.add_argument('-k', '--ksize', type=int, default=3, help='K-mer size (default: 3)')
     p.add_argument('-s', '--scaled', type=int, default=50, help='Scaled value for MinHash (default: 50)')


### PR DESCRIPTION
`kmer-composition.py` is a more flexible version of `count_3mer.py`. 
Also we actually set `track_abundance` here to count k-mer frequencies, I forgot to tell you that was needed :).

`kmer-abundance.py` takes in both the fasta and a sketch made from the full fasta. It then sketches each recordindividually to get hashes, then takes the abundances for those hashes from the full file.

For both, I normalized the abundances to the total number of k-mers observed in the record.